### PR TITLE
Fixing a few minor issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,ts,yml,json}]
+charset = utf-8
+indent_style=space
+indent_size=2
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ echo 'export PUBLIC_PORT="3000"' > .env
 echo 'export PUBLIC_IP="127.0.0.1"' > .env
 echo 'export PUBLIC_SCHEME="http"' > .env
 echo 'export SLACK_BOT_TOKEN="..."' > .env
+echo 'export DEFAULT_CHANNEL="..."' > .env
+echo 'export SLOW_POLL_RATE_SECONDS="..."' > .env
+echo 'export MINUTES_INACTIVITY_SLOWDOWN="..."' > .env
+echo 'export MINUTES_INACTIVITY_DIE="..."' > .env
 yarn start
 ```
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,8 +48,15 @@ const web = new WebClient(token);
 const redisClient = createHandyClient();
 
 //------------------------------------------------------------------------------
+// A struct to keep timeouts
+let timeouts: Record<string, ReturnType<typeof setTimeout> | undefined> = {};
+
+//------------------------------------------------------------------------------
 // Global functions
 let pollURL = async (name: string) => {
+  let timeoutId = timeouts[name];
+  if (notEmpty(timeoutId)) clearTimeout(timeoutId);
+  timeouts[name] = undefined;
   let source = await getSource(name);
   if (source === undefined) return;
   request(
@@ -118,7 +125,7 @@ let pollURL = async (name: string) => {
             );
           }
         }
-        setTimeout(() => pollURL(name), delay);
+        timeouts[name] = setTimeout(() => pollURL(name), delay);
       }
     }
   );

--- a/src/server.ts
+++ b/src/server.ts
@@ -282,7 +282,7 @@ let getReplacements = async () => {
 let replace = async (pgn: string) => {
   let replacements = await getReplacements();
   return replacements.reduce((current, r) => {
-    return current.replace(r.oldContent, r.newContent);
+    return current.replace(new RegExp(r.oldContent, "g"), r.newContent);
   }, pgn);
 };
 let addReplacement = async (event: any, replacementString: string) => {


### PR DESCRIPTION
1. Store timeout IDs and clear them when setting a source with the same name. This prevents the broadcast spam.
2. Update the README to properly document all necessary .env files.
3. Use a global replace for replacements.