### PR TITLE
accept self signed and expired certs

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -68,6 +68,7 @@ let pollURL = async (name: string) => {
         Cookie: cookie,
         "User-Agent": userAgent,
       },
+      rejectUnauthorized: false,
     },
     async (err, res, body) => {
       let source = await getSource(name);

--- a/src/server.ts
+++ b/src/server.ts
@@ -68,7 +68,7 @@ let pollURL = async (name: string) => {
         Cookie: cookie,
         "User-Agent": userAgent,
       },
-      rejectUnauthorized: false,
+      rejectUnauthorized: !source.insecure,
     },
     async (err, res, body) => {
       let source = await getSource(name);
@@ -172,6 +172,7 @@ let sourceFromJSON = (s: string): Source => {
     name: d.name,
     delay: d.delay,
     pgn: d.pgn,
+    insecure: d.insecure,
     dateLastPolled: new Date(d.dateLastPolled),
     dateLastUpdated: new Date(d.dateLastUpdated),
   };
@@ -239,6 +240,10 @@ let addOrSet = async (
   if (url.endsWith(">")) {
     url = url.slice(0, url.length - 1);
   }
+  const insecure = url.startsWith("insecure-https://");
+  if (insecure) {
+    url = url.substr("insecure-".length);
+  }
   if (!isURL(url)) {
     say(`${url} is not a valid URL`, event.channel);
     console.log(`${url} is not a valid url`);
@@ -247,6 +252,7 @@ let addOrSet = async (
   let source = {
     name,
     url,
+    insecure,
     delay,
     pgn: "",
     dateLastPolled: new Date(),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,7 @@ export interface Source {
   name: string;
   delay: number;
   pgn: string;
+  insecure: boolean;
   dateLastPolled: Date;
   dateLastUpdated: Date;
 }


### PR DESCRIPTION
WDR had issues with a tournament organizer using expired TLS certificates for their feed (which had no plain HTTP version). I checked out this branch on khiaw as a temporary workaround.

We could consider making this permanent, or maybe use a prefix like `insecure-https://` to enable the flag.